### PR TITLE
feat: Add adsb-mqtt image and workflow for MQTT publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
   - "/images/piaware"
   - "/images/tar1090"
   - "/images/ais-catcher"
+  - "/images/adsb-mqtt"
   - "/images/sdr-base"
   - "/images/sdr-build"
   - "/images/gsm-tools"

--- a/.github/workflows/build-adsb-mqtt.yml
+++ b/.github/workflows/build-adsb-mqtt.yml
@@ -1,0 +1,40 @@
+name: Build adsb-mqtt container image
+
+# Publisher image (polls dump1090-fa aircraft.json → MQTT). Pipeline shape matches
+# build-adsbexchange.yml — uses the shared reusable docker-container workflow so the image gets
+# the SLSA provenance the cluster's supply-chain policies require.
+
+on:
+  workflow_dispatch:
+    inputs:
+      grype_fail_build:
+        description: "Fail the build if Grype finds vulnerabilities"
+        type: boolean
+        default: true
+  push:
+    branches: [main]
+    paths:
+      - "images/adsb-mqtt/**"
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  actions: write
+  security-events: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  adsb-mqtt:
+    uses: hwinther/reusable-workflows/.github/workflows/docker-container.yml@67ef4a8614e14d29e0039410f41a7ab9a7af093f # v1.58.0
+    with:
+      container_image_name_postfix: adsb-mqtt
+      build_context: images/adsb-mqtt
+      dockerfile: images/adsb-mqtt/Dockerfile
+      platforms: linux/amd64,linux/arm64
+      grype_fail_build: ${{ github.event_name != 'workflow_dispatch' || fromJSON(github.event.inputs.grype_fail_build || 'true') }}

--- a/images/adsb-mqtt/Dockerfile
+++ b/images/adsb-mqtt/Dockerfile
@@ -1,0 +1,31 @@
+# adsb-mqtt: polls dump1090-fa's aircraft.json and republishes it to MQTT (mosquitto).
+#
+# Built on sdr-base (digest-pinned so Dependabot tracks the bump) for supply-chain consistency with
+# the other feeders — it carries the same reusable-workflow attestations, so the cluster's cosign /
+# SLSA policies admit it without a skip. It needs no SDR runtime itself, just python3 + paho-mqtt.
+FROM ghcr.io/hwinther/wsh-rtl-sdr/sdr-base:trixie@sha256:3096b01a06cdef7c2712f953baba7cc1319f9912a0f3aad9f4589cc918a634e0 AS runtime
+LABEL maintainer="Hans Christian Winther-Sørensen <docker@wsh.no>"
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-x", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-paho-mqtt && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=755 adsb-mqtt.py /srv/adsb-mqtt.py
+
+# Defaults — override via env / k8s ConfigMap + Secret. MQTT_HOST empty = disabled (exits cleanly).
+# MQTT_PASSWORD is intentionally NOT set here; it comes from a Secret at runtime.
+ENV MQTT_HOST="" \
+    MQTT_PORT="1883" \
+    MQTT_USERNAME="" \
+    MQTT_TOPIC="adsb/aircraft" \
+    MQTT_QOS="0" \
+    MQTT_RETAIN="false" \
+    MQTT_CLIENT_ID="adsb-mqtt" \
+    AIRCRAFT_JSON="/data/aircraft.json" \
+    POLL_INTERVAL="1" \
+    PUBLISH_UNCHANGED="false"
+
+ENTRYPOINT ["python3", "/srv/adsb-mqtt.py"]

--- a/images/adsb-mqtt/adsb-mqtt.py
+++ b/images/adsb-mqtt/adsb-mqtt.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Publish dump1090-fa's aircraft.json to MQTT.
+
+dump1090-fa has no native MQTT output; it writes a decoded aircraft snapshot (aircraft.json,
+~1 Hz) to a directory shared with tar1090. This polls that file and republishes the raw bytes to
+a single MQTT topic so downstream apps get the whole-picture-every-second feed.
+
+Configuration is via env (see Dockerfile defaults). MQTT_HOST unset = disabled. The password comes
+from MQTT_PASSWORD (a Secret in k8s) and is never baked into the image.
+"""
+import os
+import sys
+import time
+
+import paho.mqtt.client as mqtt
+
+
+def _env(name, default=None):
+    return os.environ.get(name, default)
+
+
+def _make_client(client_id):
+    # paho-mqtt 2.x requires a CallbackAPIVersion; 1.x doesn't have the enum. Support both.
+    try:
+        return mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id=client_id)
+    except AttributeError:
+        return mqtt.Client(client_id=client_id)
+
+
+def main():
+    host = _env("MQTT_HOST")
+    if not host:
+        print("MQTT_HOST not set — nothing to publish, exiting.", flush=True)
+        return 0
+
+    port = int(_env("MQTT_PORT", "1883"))
+    user = _env("MQTT_USERNAME") or None
+    password = _env("MQTT_PASSWORD") or None
+    topic = _env("MQTT_TOPIC", "adsb/aircraft")
+    qos = int(_env("MQTT_QOS", "0"))
+    retain = _env("MQTT_RETAIN", "false").lower() == "true"
+    client_id = _env("MQTT_CLIENT_ID", "adsb-mqtt")
+    path = _env("AIRCRAFT_JSON", "/data/aircraft.json")
+    interval = float(_env("POLL_INTERVAL", "1"))
+    publish_unchanged = _env("PUBLISH_UNCHANGED", "false").lower() == "true"
+
+    client = _make_client(client_id)
+    if user:
+        client.username_pw_set(user, password)
+    client.reconnect_delay_set(min_delay=1, max_delay=30)
+    print(
+        f"adsb-mqtt: mqtt://{user or ''}@{host}:{port} topic={topic} "
+        f"src={path} interval={interval}s qos={qos} retain={retain}",
+        flush=True,
+    )
+    # connect_async + loop_start handles (re)connection in the background; the publish loop never blocks on it.
+    client.connect_async(host, port, keepalive=60)
+    client.loop_start()
+
+    last = None
+    missing_logged = False
+    while True:
+        try:
+            with open(path, "rb") as fh:
+                data = fh.read()
+            missing_logged = False
+            if publish_unchanged or data != last:
+                client.publish(topic, data, qos=qos, retain=retain)
+                last = data
+        except FileNotFoundError:
+            if not missing_logged:
+                print(f"{path} not found yet (waiting for dump1090-fa)", flush=True)
+                missing_logged = True
+        except Exception as exc:  # keep the loop alive on transient read/publish errors
+            print(f"adsb-mqtt: error: {exc}", flush=True)
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Introduced a new `adsb-mqtt` image that polls `dump1090-fa`'s `aircraft.json` and republishes the data to an MQTT broker.
- Created a Dockerfile for the `adsb-mqtt` image, including necessary dependencies and environment variable configurations.
- Added a GitHub Actions workflow to build the `adsb-mqtt` container image, supporting multiple platforms and vulnerability checks.